### PR TITLE
shrink RA bundle size a bit more

### DIFF
--- a/dist-update.sh
+++ b/dist-update.sh
@@ -37,8 +37,10 @@ rm assets/ozone/png/icons/*\ -\ *
 rm assets/sounds/*.wav
 rm assets/pkg/chinese-*
 rm assets/pkg/korean-*
+cd -
 
-# ../../../../../node_modules/coffeescript/bin/coffee ../../../../../../retroarch-web/indexer . > .index-xhr
+cd frontend/frontend-web/public/assets/frontend
+zip -r -9 bundle.zip bundle
 cd -
 
 rm -rf frontend/frontend-tauri/src-tauri/ra-assets

--- a/dist-update.sh
+++ b/dist-update.sh
@@ -33,6 +33,12 @@ cd ..
 
 cd frontend/frontend-web/public/assets/frontend/bundle
 rm -rf overlays shaders filters database assets/glui assets/xmb assets/rgui
+rm assets/ozone/png/icons/*\ -\ *
+rm -r autoconfig
+rm -r info
+rm assets/sounds/*.wav
+rm assets/pkg/chinese-*
+rm assets/pkg/korean-*
 ../../../../../node_modules/coffeescript/bin/coffee ../../../../../../retroarch-web/indexer . > .index-xhr
 cd -
 

--- a/dist-update.sh
+++ b/dist-update.sh
@@ -34,12 +34,11 @@ cd ..
 cd frontend/frontend-web/public/assets/frontend/bundle
 rm -rf overlays shaders filters database assets/glui assets/xmb assets/rgui
 rm assets/ozone/png/icons/*\ -\ *
-rm -r autoconfig
-rm -r info
 rm assets/sounds/*.wav
 rm assets/pkg/chinese-*
 rm assets/pkg/korean-*
-../../../../../node_modules/coffeescript/bin/coffee ../../../../../../retroarch-web/indexer . > .index-xhr
+
+# ../../../../../node_modules/coffeescript/bin/coffee ../../../../../../retroarch-web/indexer . > .index-xhr
 cd -
 
 rm -rf frontend/frontend-tauri/src-tauri/ra-assets

--- a/frontend/frontend-web/package.json
+++ b/frontend/frontend-web/package.json
@@ -20,6 +20,7 @@
     "vite-plugin-checker": "^0.5.5"
   },
   "dependencies": {
+    "@zip.js/zip.js": "^2.7.24",
     "embedv86": "file:../embedv86",
     "gisst-player": "file:../gisst-player-ui",
     "idb-keyval": "^6.2.0",

--- a/frontend/frontend-web/src/ra.ts
+++ b/frontend/frontend-web/src/ra.ts
@@ -44,8 +44,8 @@ export function init(core:string, start:ColdStart | StateStart | ReplayStart, ma
       fetchfs.mkdirp("/home/web_user/content");
 
       const proms = [];
-      
-      proms.push(fetchfs.registerFetchFS(("/assets/frontend/bundle/.index-xhr"), "/assets/frontend/bundle", "/home/web_user/retroarch/bundle", true));
+
+      proms.push(fetchfs.fetchZip("/assets/frontend/bundle.zip","/home/web_user/retroarch/"));
 
       for(const file of manifest) {
         const file_prom = fetchfs.fetchFile("/storage/"+file.file_dest_path+"/"+file.file_hash+"-"+file.file_filename,"/home/web_user/content/"+file.file_source_path,true);

--- a/frontend/frontend-web/src/ra.ts
+++ b/frontend/frontend-web/src/ra.ts
@@ -1,6 +1,6 @@
 import './style.css';
 import IMG_STATE_ENTRY from './media/init_state.png';
-import * as fetchgitfs from './fetchfs';
+import * as fetchfs from './fetchfs';
 import {UI} from 'gisst-player';
 import {saveAs,base64EncArr} from './util';
 import * as ra_util from 'ra-util';

--- a/frontend/frontend-web/src/ra.ts
+++ b/frontend/frontend-web/src/ra.ts
@@ -1,6 +1,6 @@
 import './style.css';
 import IMG_STATE_ENTRY from './media/init_state.png';
-import * as fetchfs from './fetchfs';
+import * as fetchgitfs from './fetchfs';
 import {UI} from 'gisst-player';
 import {saveAs,base64EncArr} from './util';
 import * as ra_util from 'ra-util';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,6 +63,7 @@
     "frontend-web": {
       "version": "0.0.0",
       "dependencies": {
+        "@zip.js/zip.js": "^2.7.24",
         "embedv86": "file:../embedv86",
         "gisst-player": "file:../gisst-player-ui",
         "idb-keyval": "^6.2.0",
@@ -2219,6 +2220,16 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.24",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.24.tgz",
+      "integrity": "sha512-RKXojDXeJcqOLLDFYrPYD0z3YFRaLjuOIAka789VVPGcMeCDEQv08ypNThMt+u+R2b9ISyhWiz43UBrgV1ZcbA==",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
       }
     },
     "node_modules/abbrev": {


### PR DESCRIPTION
Fixes #62. Reducing file sizes and counts was helpful, but zipping is a big win for lots of small files.  This way we don't need to avoid including info and joypad autoconf files.