### PR TITLE
precompress storage objects after tus upload or cli insert

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -100,6 +100,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
+name = "async-compression"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +286,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -379,6 +397,15 @@ name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -518,6 +545,16 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -677,6 +714,7 @@ checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 name = "gisst"
 version = "0.1.0"
 dependencies = [
+ "async-compression",
  "async-trait",
  "bytes",
  "config",
@@ -977,6 +1015,15 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2579,3 +2626,33 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zstd"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]

--- a/backend/gisst-server/src/server.rs
+++ b/backend/gisst-server/src/server.rs
@@ -97,7 +97,7 @@ pub async fn launch(config: &ServerConfig) -> Result<()> {
                 .layer(HandleErrorLayer::new(handle_error))
                 // This map_err is needed to get the types to work out after handleerror and before servedir.
                 .map_err(|e| panic!("{:?}", e))
-                .service(ServeDir::new("storage")),
+                .service(ServeDir::new("storage").precompressed_gzip()),
         )
         .layer(Extension(app_state))
         .layer(DefaultBodyLimit::max(33554432));

--- a/backend/gisst/Cargo.toml
+++ b/backend/gisst/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
-name = "gisst"
-version = "0.1.0"
-edition = "2021"
+name                    = "gisst"
+version                 = "0.1.0"
+edition                 = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "time", "json"] }
-time = { version = "0.3.21", features = ["serde", "parsing"] }
-uuid = { version = "1.3.1", features = ["serde", "v4"] }
-serde = { version = "1.0.159", features = ["derive"] }
-serde_json = { version = "1.0.96", features = ["raw_value"] }
-thiserror = "1.0.40"
-async-trait = "0.1.68"
-log = "0.4.17"
-tokio = { version = "1.27.0", features = ["full"] }
-md5 = "0.7.0"
-bytes = { version = "1.4.0", features = ["serde"] }
-config = {  version = "0.13.3", features = ["toml"], default-features = false }
+sqlx                    = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "time", "json"] }
+time                    = { version = "0.3.21", features = ["serde", "parsing"] }
+uuid                    = { version = "1.3.1", features = ["serde", "v4"] }
+serde                   = { version = "1.0.159", features = ["derive"] }
+serde_json              = { version = "1.0.96", features = ["raw_value"] }
+thiserror               = "1.0.40"
+async-trait             = "0.1.68"
+log                     = "0.4.17"
+tokio                   = { version = "1.27.0", features = ["full"] }
+md5                     = "0.7.0"
+bytes                   = { version = "1.4.0", features = ["serde"] }
+config                  = { version = "0.13.3", features = ["toml"], default-features = false }
+async-compression       = { version = "0.4", features = ["tokio", "gzip", "zstdmt"] }


### PR DESCRIPTION
fixes #61.

The tus part is untested but seems like it Should Work (tm).

This brings bfight down by about a factor of three, v86 states by a factor of 10 or so, and maybe other stuff by other amounts.